### PR TITLE
fix: not working ssr

### DIFF
--- a/lib/src/timeago.clock.ts
+++ b/lib/src/timeago.clock.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { Observable, of, empty, timer } from 'rxjs';
 import { expand, skip } from 'rxjs/operators';
 import { MINUTE, HOUR, DAY } from './util';
@@ -9,7 +10,15 @@ export abstract class TimeagoClock {
 
 @Injectable()
 export class TimeagoDefaultClock extends TimeagoClock {
+  constructor(@Inject(PLATFORM_ID) private platformId: Object) {
+    super();
+  }
+
   tick(then: number): Observable<any> {
+    return isPlatformBrowser(this.platformId) ? this.browserTick(then) : empty();
+  }
+
+  private browserTick(then: number): Observable<any> {
     return of(0)
       .pipe(
         expand(() => {

--- a/tests/clock.spec.ts
+++ b/tests/clock.spec.ts
@@ -10,22 +10,44 @@ describe('TimeagoClock', () => {
   describe('Default', () => {
     let clock: TimeagoDefaultClock;
 
-    beforeEach(() => {
-      clock = new TimeagoDefaultClock();
-    });
-
-    it('is defined', () => {
-      expect(TimeagoDefaultClock).toBeDefined();
-
-      expect(clock instanceof TimeagoDefaultClock).toBeTruthy();
-    });
-
-    it('should complete instantly for differences greater than a day', (() => {
-      testScheduler.run(({ expectObservable }) => {
-        const source = clock.tick(Date.now() - 60 * 60 * 24 * 1000).pipe(map(x => x.toString()));
-        const expected = '|';
-        expectObservable(source).toBe(expected);
+    describe('Platform browser', () => {
+      beforeEach(() => {
+        clock = new TimeagoDefaultClock('browser');
       });
-    }));
+
+      it('is defined', () => {
+        expect(TimeagoDefaultClock).toBeDefined();
+
+        expect(clock instanceof TimeagoDefaultClock).toBeTruthy();
+      });
+
+      it('should complete instantly for differences greater than a day', (() => {
+        testScheduler.run(({ expectObservable }) => {
+          const source = clock.tick(Date.now() - 60 * 60 * 24 * 1000).pipe(map(x => x.toString()));
+          const expected = '|';
+          expectObservable(source).toBe(expected);
+        });
+      }));
+    });
+
+    describe('Platform server', () => {
+      beforeEach(() => {
+        clock = new TimeagoDefaultClock('server');
+      });
+
+      it('is defined', () => {
+        expect(TimeagoDefaultClock).toBeDefined();
+
+        expect(clock instanceof TimeagoDefaultClock).toBeTruthy();
+      });
+
+      it('should complete instantly for differences smaller than a day', (() => {
+        testScheduler.run(({ expectObservable }) => {
+          const source = clock.tick(Date.now() - 1).pipe(map(x => x.toString()));
+          const expected = '|';
+          expectObservable(source).toBe(expected);
+        });
+      }));
+    });
   });
 });


### PR DESCRIPTION
This PR resolves issue #43 

Incorrect behaviour:
If time passed to timeago pipe is less than 1 day then ssr waits for clock tick to refresh text returned by pipe.

Fixed behaviour:
Clock service is active only in browser. On other platforms clock service immediately sends `complete` event unsubscribing every listeners.